### PR TITLE
Enable setting of properties on tasks generated automatically from capistrano-multiconfig

### DIFF
--- a/lib/capistrano/multiconfig/configurations.rb
+++ b/lib/capistrano/multiconfig/configurations.rb
@@ -35,8 +35,12 @@ Capistrano::Configuration.instance.load do
     task_name = segments.last
 
     # Provide ability to add task options via equivalently named JSON file
-    task_options_file = ([config_root] + segments[0..i]).join('/') + '.json'
-    task_def = JSON.parse(File.read(task_options_file), :symbolize_names => true) if File.exists?(task_options_file)
+    task_options_file = ([config_root] + segments).join('/') + '.json'
+    begin
+      task_def = JSON.parse(File.read(task_options_file), :symbolize_names => true) if File.exists?(task_options_file)
+    rescue JSON::ParserError
+      raise SyntaxError, "Your JSON file (#{task_options_file}) does not parse"
+     end
     task_def ||= {}
     task_def[:options] = {} unless task_def.key?(:options)
     task_def[:description] = "Load #{config_name} configuration" unless task_def.key?(:description)


### PR DESCRIPTION
Hi,

capistrano-multiconfig looks great, and i wanted to use it in conjunction with the staging functionality in newer versions of capistrano so I can deploy multiple apps but to different environments.

In my individual project Cap deploy scripts I defined a task like this:

role :app, 'some-app-server.mydomain.com'
task :foo, :roles => :app

however when I use the excellent capistrano-multiconfig, it sets the task up in a lambda block without any options. I looked at ways to set the options which is impossible because Capistrano::TaskDefinition makes it an attr_reader only. I looked at ways to override roles through environment variables but to be honest that sucked a bit.

So unless there was another way to do it, I created the following patch which provides a simple solution to the problem. In addition I wanted to fix my task "descriptions" which I thought should be more verbose than the generic version that capistrano-multiconfig gives you.

The patch allows you to define a json file alongside your task file containing options and description (and can be extended later to other things), so they can be passed into the task that is automatically generated.

E.g. if I have config/deploy/some_app/some_task.rb
I can now also have:

config/deploy/some_app/some_task.json

{
  "description": "this is the real description for some_task"
  "options": {
    "roles": [
      "app"
    ]
  }
}

And everything seems to work fine again.

In this way I have created a battery of different cap scripts for different apps, all on different environments all in one place.

I didnt rebuild the Gemfile so if you're interested in the above patch you'll need to do that yourselves.

Alternatively if you have a different and more elegant way of doing the above (not using ENV variables), please do let me know, I couldnt find one!

However I normall
