### PR TITLE
Capistrano should be required first

### DIFF
--- a/lib/capistrano/multiconfig.rb
+++ b/lib/capistrano/multiconfig.rb
@@ -1,2 +1,3 @@
+require 'capistrano'
 require 'capistrano/multiconfig/configurations'
 require 'capistrano/multiconfig/ensure'


### PR DESCRIPTION
capistrano should be required before other modules/classes else uninitialized constant will be raised.

This happens if capistrano is not manually specified first in a Gemfile or required before capistrano-multiconfig.
