### PR TITLE
Allow files which start with the same name but are not equal

### DIFF
--- a/lib/capistrano/multiconfig/dsl.rb
+++ b/lib/capistrano/multiconfig/dsl.rb
@@ -39,7 +39,7 @@ module Capistrano
           file.slice(stages_root.size + 1 .. -4).tr('/', ':')
         }.tap { |paths|
           paths.reject! { |path|
-            paths.any? { |another| another != path && another.start_with?(path) }
+            paths.any? { |another| another != path && another.eql?(path) }
           }
         }.sort
       end


### PR DESCRIPTION
Fixes this issue https://github.com/railsware/capistrano-multiconfig/issues/10
