### PR TITLE
Fix errors about Capistrano::DSL

### DIFF
--- a/lib/capistrano/multiconfig.rb
+++ b/lib/capistrano/multiconfig.rb
@@ -1,3 +1,4 @@
+require 'capistrano/all'
 require 'capistrano/multiconfig/dsl'
 
 include Capistrano::DSL


### PR DESCRIPTION
Capistrano doesn't load itself by default when you call Bundler.require...you need to require 'capistrano/all' in order to load it.  When capistrano-multiconfig is included in a Rails project, running any rake task results in the following error:

NameError: uninitialized constant Capistrano::DSL
/Users/adam/code/project/vendor/bundle/ruby/2.1.0/gems/capistrano-multiconfig-3.0.8/lib/capistrano/multiconfig.rb:4:in `<top (required)>'

This patch fixes the error.
