### PR TITLE
Added "capistrano_multiconfig_parallel" as a project that uses this gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,4 @@ Specify in `Capfile`:
 
 * [capistrano](https://github.com/capistrano/capistrano)
 * [caphub](https://github.com/railsware/caphub)
-
+* [capistrano_multiconfig_parallel](https://github.com/bogdanRada/capistrano_multiconfig_parallel)


### PR DESCRIPTION
CapistranoMulticonfigParallel is a project made to allow users to run tasks in parallel .
It has it's own executable,so that this project won't interfere with capistrano or other gems. 

You can find more details on the readme file of the repository : https://github.com/bogdanRada/capistrano_multiconfig_parallel

Also, if is needed i can change the gem name if you think is too similar or any other reason. I am opened to suggestions. 

I think this could be also a solution for this issue: https://github.com/railsware/capistrano-multiconfig/issues/12
 
I might be wrong, but please do share your opinion. Thank you very much. 
