### PR TITLE
Capistrano 3.5.0 has required airbrussh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "capistrano", "3.0.0"
+gem "capistrano", "3.5.0"
 
 group :test do
   gem "rspec", "2.14.1"

--- a/lib/capistrano/multiconfig.rb
+++ b/lib/capistrano/multiconfig.rb
@@ -9,6 +9,15 @@ namespace :load do
   end
 end
 
+if Gem::Version.new(Capistrano::VERSION) >= Gem::Version.new('3.5.0')
+  require "airbrussh/capistrano"
+
+  Airbrussh.configure do |airbrussh|
+    airbrussh.banner = false
+    airbrussh.command_output = true
+  end
+end
+
 stages.each do |stage|
   Rake::Task.define_task(stage) do
 


### PR DESCRIPTION
In Cap 3.5.0, setup.rb has required new formatter [airbrussh](https://github.com/mattbrictson/airbrussh). It should require "airbrussh/capistrano" in capistrano/multiconfig. If not, it will raise an error like the following:

```console
$ bundle exec cap app:integration deploy --trace
** Invoke app:integration (first_time)
** Execute app:integration
** Invoke load:defaults (first_time)
** Execute load:defaults
cap aborted!
NameError: Unrecognized SSHKit::Formatter "airbrussh"
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/sshkit-1.10.0/lib/sshkit/configuration.rb:85:in `formatter_class'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/sshkit-1.10.0/lib/sshkit/configuration.rb:62:in `use_format'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/capistrano-3.5.0/lib/capistrano/configuration.rb:154:in `configure_sshkit_output'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/capistrano-3.5.0/lib/capistrano/configuration.rb:92:in `block in configure_backend'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/sshkit-1.10.0/lib/sshkit.rb:11:in `configure'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/capistrano-3.5.0/lib/capistrano/configuration.rb:91:in `configure_backend'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/capistrano-multiconfig-3.0.8/lib/capistrano/multiconfig.rb:48:in `block (2 levels) in <top (required)>'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/task.rb:248:in `call'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/task.rb:248:in `block in execute'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/task.rb:243:in `each'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/task.rb:243:in `execute'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/task.rb:187:in `block in invoke_with_call_chain'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/task.rb:180:in `invoke_with_call_chain'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/task.rb:173:in `invoke'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/application.rb:150:in `invoke_task'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/application.rb:106:in `each'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/application.rb:106:in `block in top_level'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/application.rb:115:in `run_with_threads'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/application.rb:100:in `top_level'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/application.rb:78:in `block in run'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/application.rb:176:in `standard_exception_handling'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/rake-11.1.2/lib/rake/application.rb:75:in `run'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/capistrano-3.5.0/lib/capistrano/application.rb:14:in `run'
/Users/hfm/src/github.com/hfm/my_app/.bundle/gems/capistrano-3.5.0/bin/cap:3:in `<top (required)>'
/Users/hfm/src/github.com/hfm/my_app/.bundle/bin/cap:23:in `load'
/Users/hfm/src/github.com/hfm/my_app/.bundle/bin/cap:23:in `<top (required)>'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `load'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:63:in `kernel_load'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/lib/bundler/cli/exec.rb:24:in `run'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/lib/bundler/cli.rb:304:in `exec'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/lib/bundler/cli.rb:11:in `start'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/exe/bundle:27:in `block in <top (required)>'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/lib/bundler/friendly_errors.rb:98:in `with_friendly_errors'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.12.5/exe/bundle:19:in `<top (required)>'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/bin/bundle:23:in `load'
/Users/hfm/.anyenv/envs/rbenv/versions/2.1.4/bin/bundle:23:in `<main>'
Tasks: TOP => app:integration
```