### PR TITLE
Fix SCM loader for Capistrano v3.7.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "capistrano", "3.5.0"
+gem "capistrano", "3.7.1"
 
 group :test do
   gem "rspec", "2.14.1"

--- a/lib/capistrano/multiconfig.rb
+++ b/lib/capistrano/multiconfig.rb
@@ -47,9 +47,6 @@ stages.each do |stage|
       load(file) if File.exists?(file)
     end
 
-    # Load SCM tasks
-    load "capistrano/#{fetch(:scm)}.rb"
-
     # Set locale
     I18n.locale = fetch(:locale, :en)
 


### PR DESCRIPTION
Because: https://github.com/capistrano/capistrano/tree/v3.7.0/lib/capistrano/scm