### PR TITLE
NoMethodError: undefined method `exists?' for File:Class

### DIFF
--- a/lib/capistrano/multiconfig.rb
+++ b/lib/capistrano/multiconfig.rb
@@ -44,7 +44,7 @@ stages.each do |stage|
       paths << File.join(paths.last, segment)
     end.each do |path|
       file = "#{path}.rb"
-      load(file) if File.exists?(file)
+      load(file) if File.exist?(file)
     end
 
     # Set locale


### PR DESCRIPTION
removed in Ruby 3.2.0

https://ruby-doc.org/core-2.2.0/File.html#method-c-exists-3F

https://bugs.ruby-lang.org/issues/17391